### PR TITLE
Update urls.py to support Django 1.10

### DIFF
--- a/openid_provider/urls.py
+++ b/openid_provider/urls.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 # vim: set ts=4 sw=4 : */
 
-try:
-    from django.conf.urls import patterns, url
-except ImportError:  # Django < 1.4
-    from django.conf.urls.defaults import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns('openid_provider.views',
-    url(r'^$', 'openid_server', name='openid-provider-root'),
-    url(r'^decide/$', 'openid_decide', name='openid-provider-decide'),
-    url(r'^xrds/$', 'openid_xrds', name='openid-provider-xrds'),
-    url(r'^(?P<id>.*)/$', 'openid_xrds', {'identity': True}, name='openid-provider-identity'),
-)
+from . import views
+
+urlpatterns = [
+    url(r'^$', views.openid_server, name='openid-provider-root'),
+    url(r'^decide/$', views.openid_decide, name='openid-provider-decide'),
+    url(r'^xrds/$', views.openid_xrds, name='openid-provider-xrds'),
+    url(r'^(?P<id>.*)/$', views.openid_xrds, {'identity': True}, name='openid-provider-identity'),
+]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "django_openid_provider",
-    version = "0.6+nimbis.1",
+    version = "0.7+nimbis.1",
     author = u"Roman Barczyński",
     description = "An OpenID provider for your django.contrib.auth accounts",
     long_description = open("README.txt").read(),


### PR DESCRIPTION
Django 1.10 no longer allows you to specify views as a string in your
URL patterns.